### PR TITLE
proof of concept for handling expressions such as println_f!("file: {…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,26 @@ mk_macros! { @with_dollar![$]=>
     writeln_f
         => writeln!(stream, ...)
     ,
+    #[doc = "Shorthand for [`error!(format_f!`]."]
+    error_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`warn!(format_f!`]."]
+    warn_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`info!(format_f!`]."]
+    info_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`debug!(format_f!`]."]
+    debug_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`trace!(format_f!`]."]
+    trace_f
+        => debug!(...)
+    ,
 }
 
 /// Like [`format_args!`](

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro2 = "0.4.30"
 proc-macro-hack = "0.5.8"
 proc-quote = "0.2.2"
 syn = { version = "0.15.42", features = ["full", ]}
+regex = "1.3.1"
 
 [features]
 verbose-expansions = ["syn/extra-traits", ]

--- a/src/proc_macro/mod.rs
+++ b/src/proc_macro/mod.rs
@@ -186,7 +186,8 @@ fn format_args_f (input: TokenStream) -> TokenStream
         }
     }
     frmt.push('"');
- 
+    format_literal = parse_str::<LitStr>(frmt.as_str()).unwrap();
+
     TokenStream::from(debug_output!(quote! {
         format_args!(#format_literal #(, #extra_args)*)
     }))

--- a/src/proc_macro/mod.rs
+++ b/src/proc_macro/mod.rs
@@ -94,11 +94,7 @@ fn format_args_f (input: TokenStream) -> TokenStream
         mut extra_args,
     } = parse_macro_input!(input);
     let s = format_literal.value();
-
-    // this might be easier to maintain if we were to tokenize the
-    // string and handle tokens rather than characters.
     let mut iterator = s.chars().peekable();
-    
     let mut curly_bracket_count = 0;
     let mut frmt = String::new();
     let mut item = String::new();


### PR DESCRIPTION
this is a proof of concept for handling expressions such as:

```
    struct Foo { a: i64 }
    let foo = Foo { a: 1234 };
    println_f!("foo.a: {foo.a}");
```
it works for this simple example, and for certain others as long as ':' doesn't occur in the expression inside {}.  