### PR TITLE
add convenience debug_f!() macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,26 @@ mk_macros! { @with_dollar![$]=>
     writeln_f
         => writeln!(stream, ...)
     ,
+    #[doc = "Shorthand for [`error!(format_f!`]."]
+    error_f
+    =>debug!(...)
+    ,
+    #[doc = "Shorthand for [`warn!(format_f!`]."]
+    warn_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`info!(format_f!`]."]
+    info_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`debug!(format_f!`]."]
+    debug_f
+        => debug!(...)
+    ,
+    #[doc = "Shorthand for [`trace!(format_f!`]."]
+    trace_f
+        => debug!(...)
+     ,
 }
 
 /// Like [`format_args!`](


### PR DESCRIPTION
Here are the proposed debug macros.  Please feel free to change as needed.  It does not attempt to add a feature flag.

The new code for accessing struct members looks wonderful.

And thanks for adding the = syntax.  Having continued to use and think about it, your reasoning about best practices make a lot of sense.  I don't envision further suggestion at this time.