### PR TITLE
fixed self parameter parsing

### DIFF
--- a/src/proc_macro/mod.rs
+++ b/src/proc_macro/mod.rs
@@ -127,7 +127,7 @@ fn format_args_f (input: TokenStream) -> TokenStream
             continue;
         }
 
-        enum Segment { Ident(Ident), LitInt(LitInt) }
+        enum Segment { Ident(Ident), LitInt(LitInt), Self_(Token![self]) }
         let segments: Vec<Segment> = {
             impl Parse for Segment {
                 fn parse (input: ParseStream<'_>)
@@ -138,6 +138,8 @@ fn format_args_f (input: TokenStream) -> TokenStream
                         input.parse().map(Segment::Ident)
                     } else if lookahead.peek(LitInt) {
                         input.parse().map(Segment::LitInt)
+                    } else if input.peek(Token![self]){
+                        input.parse().map(Segment::Self_)
                     } else {
                         Err(lookahead.error())
                     }
@@ -174,6 +176,9 @@ fn format_args_f (input: TokenStream) -> TokenStream
                             ));
                         }
                     },
+                    | Segment::Self_(ident) => {
+                        continue;
+                    },
                 }
             },
             | _ => {
@@ -190,6 +195,9 @@ fn format_args_f (input: TokenStream) -> TokenStream
                             },
                             | Segment::LitInt(literal) => {
                                 literal.into_token_stream()
+                            },
+                            | Segment::Self_(self_) => {
+                                self_.into_token_stream()
                             },
                         })
                         .collect()


### PR DESCRIPTION
Currently, this code below doesn't work. This PR fixes it.
``` python
#![feature(trace_macros)]

trace_macros!(true);
use fstrings::{f, format_args_f};

struct Temp {
    text: String
}

impl Temp {
    fn fs(&self) -> String {
        f!("{self.text}|")
    }
}


fn main() {
    let tmp = Temp {text: "Value".to_string()};
    let output = tmp.fs();
    println!("{}", output);
}
```