### PR TITLE
Make the crate work without `#[macro_use]` on `extern crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! mk_macros {( @with_dollar![$dol:tt]=>
         macro_rules! $printlnf {(
             $($dol $stream : expr,)? $dol($dol args:tt)*
         ) => (
-            $println!($($dol $stream,)? "{}", format_args_f!($dol($dol args)*))
+            $println!($($dol $stream,)? "{}", $crate::format_args_f!($dol($dol args)*))
         )}
     )*
 )}


### PR DESCRIPTION
(The inner `format_args_f!` was missing its `$crate::` qualifier).

Fixes #11 

cc @jeremychone does this branch fix the issue?

  - To test it, use this for your `Cargo.toml` file:

    ```toml
    [dependencies]
    # fstrings = "…"
    fstrings.git = "https://github.com/danielhenrymantilla/fstrings-rs"
    fstrings.branch = "danielhenrymantilla-patch-2"
    ```

  - If it works, I shall merge this and make a `0.2.4` release to crates.io